### PR TITLE
chore: Use Wayland by default

### DIFF
--- a/com.jetbrains.RustRover.yml
+++ b/com.jetbrains.RustRover.yml
@@ -20,7 +20,8 @@ finish-args:
   - --share=network
   - --socket=gpg-agent
   - --socket=ssh-auth
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets


### PR DESCRIPTION
Enable Wayland with X11 as fallback. Starting with 2026.1, IntelliJ-based IDEs will run natively on Wayland.
https://blog.jetbrains.com/platform/2026/02/wayland-by-default-in-2026-1-eap/

This change requires: #38 